### PR TITLE
Fix backup and restore scripts

### DIFF
--- a/scripts/db_backup.sh
+++ b/scripts/db_backup.sh
@@ -3,6 +3,12 @@ set -e
 
 if [ -z "${BACKUP_DIR}" ]; then
     echo "\$BACKUP_DIR must be set."
+    exit 1
+fi
+
+if [ -z "${DB_USER}" ]; then
+    echo "\$DB_USER must be set."
+    exit 1
 fi
 
 if (facter cname | grep blue); then
@@ -11,5 +17,5 @@ else
     bkpfile="$BACKUP_DIR/usaon-benefit-tool-db-backup.sql.gz"
 fi
 
-docker exec --tty db pg_dumpall --clean --username dbuser | gzip > $bkpfile
+docker exec --tty db pg_dumpall --clean --username "$DB_USER" | gzip > $bkpfile
 echo "Backup saved to $bkpfile."

--- a/scripts/db_restore.sh
+++ b/scripts/db_restore.sh
@@ -21,8 +21,8 @@ fi
 docker compose restart
 $SCRIPTPATH/wait_for_db.sh
 
-docker exec db dropdb usaon-benefit-tool || true
-docker exec db createdb usaon-benefit-tool 
+docker exec db dropdb --user="${DB_USER}" usaon-benefit-tool || true
+docker exec db createdb --user="${DB_USER}" usaon-benefit-tool 
 
 gunzip -c $bkpfile | docker exec --interactive db psql --username "$DB_USER"
 echo "Restored from $bkpfile."

--- a/scripts/db_restore.sh
+++ b/scripts/db_restore.sh
@@ -6,12 +6,14 @@ SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
 if [ -n "$1" ]; then
     bkpfile="$1"
-elif [ -n "${BACKUP_DIR}" ]; then
-    bkpfile="$(find $BACKUP_DIR -name "usaon-benefit-tool-db-backup.sql.gz*" | sort -r | head -1)"
 fi
 
 if [ -z "$bkpfile" ]; then
-    echo "Please pass a backup file as argument or set \$BACKUP_DIR and ensure a backup file exists there"
+    echo "Please pass a path to a backup file as argument."
+
+    if [ -n "$BACKUP_DIR" ]; then
+        echo "They can most likely be found in ${BACKUP_DIR}."
+    fi
     exit 1
 fi
 
@@ -22,5 +24,5 @@ $SCRIPTPATH/wait_for_db.sh
 docker exec db dropdb usaon-benefit-tool || true
 docker exec db createdb usaon-benefit-tool 
 
-gunzip -c $bkpfile | docker exec --interactive db psql --username dbuser
+gunzip -c $bkpfile | docker exec --interactive db psql --username "$DB_USER"
 echo "Restored from $bkpfile."

--- a/scripts/db_restore.sh
+++ b/scripts/db_restore.sh
@@ -18,7 +18,7 @@ if [ -z "$bkpfile" ]; then
 fi
 
 # restart to boot any active sesssions
-docker-compose restart
+docker compose restart
 $SCRIPTPATH/wait_for_db.sh
 
 docker exec db dropdb usaon-benefit-tool || true


### PR DESCRIPTION
dbuser is a Unix user in the Docker image, so it looks right. $DB_USER contains the username ("role") that's configured in the database itself.

Removed the ability to automatically restore from an unspecified backup file. That's dangerous. If we want this logic to find the latest backup file, we should be doing it in a calling script, not as a default behavior!